### PR TITLE
Update slides data on window resize

### DIFF
--- a/src/components/Carousel.ts
+++ b/src/components/Carousel.ts
@@ -112,6 +112,7 @@ export default defineComponent({
 
     const handleWindowResize = debounce(() => {
       updateBreakpointsConfigs()
+      updateSlidesData()
       updateSlideWidth()
     }, 16)
 


### PR DESCRIPTION
Ensures the slides data gets updated when the window resizes to avoid the `minSlideIndex` and `maxSlideIndex` to be outdated when `itemsToShow` is overridden for a breakpoint.

Reproduceable example:
```
<Carousel
  snap-align="center"
  :items-to-show="1"
  :breakpoints="{
    1024: {
      itemsToShow: 2,
      snapAlign: 'start',
    },
  }"
>
  <!--  Insert 3 slides -->
</Carousel>
 ```
 
 Note how the `maxSlideIndex` doesn't get adjusted from `2` to `1` when increasing the window size to above 1024px.
 
 After this fix, the `maxSlideIndex` will be adjusted accordingly.